### PR TITLE
refactor(certificate-importer): update export data structure and docs

### DIFF
--- a/certificate-importer/README.md
+++ b/certificate-importer/README.md
@@ -1,6 +1,6 @@
 # Mass Certificate Insertion Script
 
-This Python script allows you to **mass-insert certificates into a MongoDB database** from a CSV file and **export the certificate information** (name, email, and generated credential ID) to a CSV file.
+This Python script allows you to **mass-insert certificates into a MongoDB database** from a CSV file and **export the certificate information** (email, name, credential ID, and credential URL) to a CSV file.
 
 ## Requirements
 
@@ -12,9 +12,9 @@ pip install -r requirements.txt
 
 **Dependencies include:**
 
-* `pandas`
-* `python-dotenv`
-* `pymongo`
+- `pandas`
+- `python-dotenv`
+- `pymongo`
 
 ## Setup
 
@@ -39,15 +39,19 @@ COURSE=Club Member
 ISSUER=Mozilla Campus Club SLIIT
 
 # -------------------- CSV Configuration --------------------
-CSV_INPUT_FILE=participants.csv      # Input CSV file with participant data
-CSV_NAME_COL=name                    # Column in CSV containing participant names
-CSV_EMAIL_COL=email                  # Column in CSV containing participant emails 
-CSV_OUTPUT_FILE=certificates_export.csv  # CSV file to export name, email, and credentialId
+CSV_INPUT_FILE=participants.csv        # Input CSV file with participant data
+CSV_NAME_COL=name                      # Column in CSV containing participant names
+CSV_EMAIL_COL=email                    # Column in CSV containing participant emails
+CSV_OUTPUT_FILE=certificates_export.csv  # CSV file to export data
+
+# -------------------- Certificate URL --------------------
+BASE_URL=https://certify.sliitmozilla.org/certificate/
 ```
 
 **Notes:**
 
-* CSV can have **any number of columns**, as long as you correctly specify the `name` and `email` columns inside ```.env``` file.
+- CSV can have **any number of columns**, as long as you correctly specify the `name` and `email` columns inside `.env`.
+- `BASE_URL` is used to build the credential URL for each certificate but is **not stored in MongoDB** — only added in the exported CSV.
 
 ## Usage
 
@@ -68,8 +72,7 @@ Do you want to continue? (y/n):
 3. Certificates are **inserted into MongoDB**, and logs are displayed for each insertion.
 4. After completion, an **export CSV** is generated containing:
 
-| name         | email                                         | credentialId    |
-| ------------ | --------------------------------------------- | --------------- |
-| Saman Silva  | [saman@example.com](mailto:saman@example.com) | a9b7c8d6e5f4... |
-| Nimal Perera | [nimal@example.com](mailto:nimal@example.com) | b8c7d6e5f4a3... |
-
+| email                                         | name         | credId        | credUrl                                                                                                                  |
+| --------------------------------------------- | ------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| [saman@example.com](mailto:saman@example.com) | Saman Silva  | a9b7c8d6e5f4… | [https://certify.sliitmozilla.org/certificate/a9b7c8d6e5f4…](https://certify.sliitmozilla.org/certificate/a9b7c8d6e5f4…) |
+| [nimal@example.com](mailto:nimal@example.com) | Nimal Perera | b8c7d6e5f4a3… | [https://certify.sliitmozilla.org/certificate/b8c7d6e5f4a3…](https://certify.sliitmozilla.org/certificate/b8c7d6e5f4a3…) |

--- a/certificate-importer/app.py
+++ b/certificate-importer/app.py
@@ -28,6 +28,8 @@ csv_name_col = os.getenv("CSV_NAME_COL")
 csv_email_col = os.getenv("CSV_EMAIL_COL")    
 csv_output_file = os.getenv("CSV_OUTPUT_FILE", "certificates_export.csv")  
 
+base_url = os.getenv("BASE_URL", "https://certify.sliitmozilla.org/certificate/")
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
@@ -99,14 +101,19 @@ for _, row in df.iterrows():
         collection.insert_one(certificate)
         logging.info(f"Inserted certificate for {name}")
 
-        export_data.append({"name": name, "email": email, "credentialId": credential_id})
+        export_data.append({
+            "email": email,
+            "name": name,
+            "credId": credential_id,
+            "credUrl": f"{base_url}{credential_id}"
+        })
 
     except Exception as e:
         logging.error(f"Failed to insert certificate for row {row}: {e}")
 
 if export_data:
     try:
-        export_df = pd.DataFrame(export_data)
+        export_df = pd.DataFrame(export_data, columns=["email", "name", "credId", "credUrl"])
         export_df.to_csv(csv_output_file, index=False)
         logging.info(f"Exported credentials to {csv_output_file}")
     except Exception as e:

--- a/certificate-importer/certificates_export.csv
+++ b/certificate-importer/certificates_export.csv
@@ -1,11 +1,11 @@
-name,email,credentialId
-Saman Silva,saman@example.com,wdefb012b14244e00878dd5915601fabe
-Nimal Perera,nimal@example.com,p369e745074c142b8b76a403439e98131
-Kamal Fernando,kamal@example.com,h3febfcbacd414cdea4671170666d7fe5
-Amal Jayasinghe,amal@example.com,z539e391a47c14add986cbab831d640f5
-Chathura Wickramasinghe,chathura@example.com,kb9f5ba833b8340f6b7f47558df749de4
-Dilani Fernando,dilani@example.com,y29b7a7981537435c82f40fa5993bc928
-Ramesh Kumara,ramesh@example.com,d77a6b2762f4e4b79bdc99502607f2eba
-Sanduni Perera,sanduni@example.com,u7c9917c40f614c9a97ff1b31b4171956
-Thilina Jayawardena,thilina@example.com,j0c679217c1714ee9ab952fa33f100af3
-Nadeesha Silva,nadeesha@example.com,rd38d949caa4647db9e57e51fbcc5d650
+email,name,credId,credUrl
+saman@example.com,Saman Silva,td04423b6ca9a4f258159fa5d2f3db0fd,https://certify.sliitmozilla.org/certificate/td04423b6ca9a4f258159fa5d2f3db0fd
+nimal@example.com,Nimal Perera,m594d0f75f1af48f4b1541d2945acdfe8,https://certify.sliitmozilla.org/certificate/m594d0f75f1af48f4b1541d2945acdfe8
+kamal@example.com,Kamal Fernando,o7df0cc47b935438682da12af02f0fe94,https://certify.sliitmozilla.org/certificate/o7df0cc47b935438682da12af02f0fe94
+amal@example.com,Amal Jayasinghe,ha6132d3dfe5f4d5086e21d2424c3dfb0,https://certify.sliitmozilla.org/certificate/ha6132d3dfe5f4d5086e21d2424c3dfb0
+chathura@example.com,Chathura Wickramasinghe,p29884fca8a4a4352aedd36abc3e48b3d,https://certify.sliitmozilla.org/certificate/p29884fca8a4a4352aedd36abc3e48b3d
+dilani@example.com,Dilani Fernando,k8ea73d22d57c4bf8b72c398e81a2c751,https://certify.sliitmozilla.org/certificate/k8ea73d22d57c4bf8b72c398e81a2c751
+ramesh@example.com,Ramesh Kumara,c40471bf2da794540a6c64f3aa712eb0c,https://certify.sliitmozilla.org/certificate/c40471bf2da794540a6c64f3aa712eb0c
+sanduni@example.com,Sanduni Perera,lf257814417bf4a7ab80901d70233f1ab,https://certify.sliitmozilla.org/certificate/lf257814417bf4a7ab80901d70233f1ab
+thilina@example.com,Thilina Jayawardena,f4d395f573d4b4528ba9837736b11631a,https://certify.sliitmozilla.org/certificate/f4d395f573d4b4528ba9837736b11631a
+nadeesha@example.com,Nadeesha Silva,x2c604a79a5924048bea8542916a3115b,https://certify.sliitmozilla.org/certificate/x2c604a79a5924048bea8542916a3115b

--- a/src/models/certificate.py
+++ b/src/models/certificate.py
@@ -1,5 +1,5 @@
-from pydantic import BaseModel, Field
-from datetime import date
+from pydantic import BaseModel, Field, field_validator
+from datetime import date, datetime
 from typing import List
 from .signature import Signature
 
@@ -13,6 +13,12 @@ class Certificate(BaseModel):
     dateIssued: date = Field(..., description="Date certificate was issued")
     issuer: str = Field(..., description="Certificate issuer")
     signatures: List[Signature] = Field(..., description="List of signature objects")
-    
+
+    @field_validator("dateIssued", mode="before")
+    def parse_date_issued(cls, v):
+        if isinstance(v, str):
+            return datetime.strptime(v.strip(), "%Y-%m-%d").date()
+        return v
+
     class Config:
-        allow_population_by_field_name = True
+        populate_by_name = True

--- a/vercel.json
+++ b/vercel.json
@@ -2,14 +2,14 @@
   "version": 2,
   "builds": [
     {
-      "src": "main.py",
+      "src": "src/main.py",
       "use": "@vercel/python"
     }
   ],
   "routes": [
     {
       "src": "/(.*)",
-      "dest": "/main.py"
+      "dest": "src/main.py"
     }
   ]
 }


### PR DESCRIPTION
#11 

This PR updates the certificate importer script and documentation:

**Refactor**
 - Changed CSV export structure to: email, name, credId, credUrl.
- Introduced BASE_URL in .env for generating credential URLs.
- Ensured credUrl is only included in the exported CSV, not stored in MongoDB.

**Docs**
- Updated README with new .env configuration (BASE_URL).
- Revised usage instructions and updated export CSV example table.